### PR TITLE
synchronized urlchecker-action to latest release

### DIFF
--- a/.github/workflows/check-url.yml
+++ b/.github/workflows/check-url.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           java-version: 11
       - name: urls-checker
-        uses: urlstechie/urlchecker-action@0.2.31
+        uses: urlstechie/urlchecker-action@0.0.27
         with:
           subfolder: _data, _site
           file_types: .yml, .yaml, .html


### PR DESCRIPTION
`We are going to be deprecating older versions of urlchecker (and there was a change in versioning to match the upstream package so the version only appears earlier) so I wanted to update here to make sure your workflows do not break! To be clear, 0.0.27 is actually the newest release. https://github.com/urlstechie/urlchecker-action/releases/tag/0.0.27`
