### PR TITLE
updated wildfly swarm url to thorntail end of an era post

### DIFF
--- a/_site/community/index.html
+++ b/_site/community/index.html
@@ -217,7 +217,7 @@ Inside our KIE organization you will find various streams where you can follow a
           
             <li><a href="http://teiid.jboss.org/" target="_blank">Teiid</a></li>
           
-            <li><a href="http://wildfly-swarm.io/" target="_blank">WildFly Swarm</a></li>
+            <li><a href="https://thorntail.io/posts/the-end-of-an-era/" target="_blank">WildFly Swarm</a></li>
           
             <li><a href="http://wise.jboss.org/" target="_blank">Wise</a></li>
           


### PR DESCRIPTION
Updated URL is more appropriate to inform visitors about migrating from WildFly Swarm.

Issue: https://github.com/kiegroup/kogito-website/issues/53