### PR TITLE
NO-ISSUE: Remove obsolete desktop modeler hub documentation

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -53,8 +53,6 @@ You have gone through the <a href="{{site.baseurl}}/get-started">Getting Started
 
 Kogito provides extensions and application graphical modelers that you can use to design Business Process Model and Notation (BPMN) process models and Decision Model and Notation (DMN) decision models for your Kogito services.
 
-For convenience, all Kogito BPMN and DMN modelers are available in the [Business Modeler Hub desktop application](https://docs.kogito.kie.org/latest/html_single/#proc-kogito-modelers_kogito-creating-running).
-
 <a href="https://docs.kogito.kie.org/latest/html_single/#con-kogito-modelers_kogito-creating-running" class="button-cta secondary">READ THE GUIDE</a>
 </div>
 


### PR DESCRIPTION
We have removed kogito modeler hub and desktop application while ago.
- https://github.com/kiegroup/kie-tools/pull/706
- https://github.com/kiegroup/kie-tools/pull/1351

However we still have some references in the documentation.
- https://docs.kogito.kie.org/latest/html_single/#con-kogito-modelers_kogito-creating-running

<!-- 
PLEASE DON'T UPDATE THE _site DIRECTORY!!! IT'S AUTO GENERATED!
-->

- [ ] I installed [Jekyll](https://jekyllrb.com/docs/) locally
- [ ] I ran `bundle exec jekyll build` before sending this PR

or

- [ ] I ran `docker run --rm --volume="$PWD:/srv/jekyll" -it -p 4000:4000 jekyll/jekyll:3 jekyll serve`

